### PR TITLE
fix: header changes for landing page

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,7 @@
 // import React from "react";
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Landing from './pages/landing';
+import Header from './shared/AppWrapper/Header';
 
 import { PageMapping } from './shared/globalTypes';
 
@@ -9,15 +10,24 @@ function App(): JSX.Element {
     <Router>
       <Routes>
         {Array.from(PageMapping.keys()).map((path) => {
+          const component = PageMapping.get(path)?.component();
           return (
             <Route
               key={path}
               path={path}
-              element={PageMapping.get(path)?.component()}
+              element={
+                path === '/' ? (
+                  component
+                ) : (
+                  <>
+                    <Header />
+                    {component}
+                  </>
+                )
+              }
             />
           );
         })}
-        <Route path="/" element={<Landing />} />
       </Routes>
     </Router>
   );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -15,7 +15,7 @@ function App(): JSX.Element {
               key={path}
               path={path}
               element={
-                path === '/' ? (
+                PageMapping.get(path)?.hideHeader ? (
                   component
                 ) : (
                   <>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,5 @@
 // import React from "react";
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Landing from './pages/landing';
 import Header from './shared/AppWrapper/Header';
 
 import { PageMapping } from './shared/globalTypes';

--- a/src/components/pages/creation.tsx
+++ b/src/components/pages/creation.tsx
@@ -1,11 +1,9 @@
 import '../../styles/global.scss';
-import Header from '../shared/AppWrapper/Header';
 import Bar from '../shared/progressbar';
 
 function Creation(): JSX.Element {
   return (
     <div>
-      <Header />
       <h1 className="lesson-title">Creation and Deletion</h1>
       <p className="body">
         At the heart of any project is the ability to create and delete things.

--- a/src/components/pages/game.tsx
+++ b/src/components/pages/game.tsx
@@ -1,12 +1,5 @@
-import Header from '../shared/AppWrapper/Header';
-
 function Game(): JSX.Element {
-  return (
-    <div>
-      <Header />
-      Game
-    </div>
-  );
+  return <div>Game</div>;
 }
 
 export default Game;

--- a/src/components/pages/intro.tsx
+++ b/src/components/pages/intro.tsx
@@ -1,10 +1,8 @@
 import tuxSittingImage from '../../assets/images/tux-sitting.svg';
-import Header from '../shared/AppWrapper/Header';
 
 function Intro(): JSX.Element {
   return (
     <div>
-      <Header />
       intro
       <img src={tuxSittingImage} alt="tux the penguin sitting" />
     </div>

--- a/src/components/pages/moving.tsx
+++ b/src/components/pages/moving.tsx
@@ -1,10 +1,8 @@
 import tuxHoldingEgg from '../../assets/images/tux-hugging-egg.svg';
-import Header from '../shared/AppWrapper/Header';
 
 function Moving(): JSX.Element {
   return (
     <div>
-      <Header />
       <h1>Moving Around the File System</h1>
       <p>
         Ok, we can now figure out information about ourselves, from where to who

--- a/src/components/pages/permissions.tsx
+++ b/src/components/pages/permissions.tsx
@@ -1,10 +1,8 @@
 import tuxHoldingEgg from '../../assets/images/tux-egg-flippers-raised.svg';
-import Header from '../shared/AppWrapper/Header';
 
 function Permissions(): JSX.Element {
   return (
     <div>
-      <Header />
       Permissions
       <img
         src={tuxHoldingEgg}

--- a/src/components/pages/piping.tsx
+++ b/src/components/pages/piping.tsx
@@ -1,11 +1,9 @@
 import tuxHoldingEgg from '../../assets/images/tux-holding-egg.svg';
-import Header from '../shared/AppWrapper/Header';
 import '../../styles/piping.scss';
 
 function Piping(): JSX.Element {
   return (
     <>
-      <Header />
       <div className="lesson-container">
         <h1>Lesson Title</h1>
         <div className="section">

--- a/src/components/pages/searching.tsx
+++ b/src/components/pages/searching.tsx
@@ -1,5 +1,4 @@
 import tuxPointing from '../../assets/images/tux-pointing.svg';
-import Header from '../shared/AppWrapper/Header';
 import Modal from '../shared/Modal';
 import Task from './../shared/Task';
 import './../../styles/searching.scss';
@@ -18,7 +17,6 @@ function Searching(): JSX.Element {
 
   return (
     <>
-      <Header />
       <div className="container">
         <h2 className="header-text">Lesson Title</h2>
         <p>

--- a/src/components/pages/stationary.tsx
+++ b/src/components/pages/stationary.tsx
@@ -1,10 +1,8 @@
 import tuxBehindIgloo from '../../assets/images/tux-behind-igloo.svg';
-import Header from '../shared/AppWrapper/Header';
 
 function Stationary(): JSX.Element {
   return (
     <div>
-      <Header />
       <h1>Stationary Commands</h1>
       <p>
         Linux and the POSIX file system might seem confusing at first, but if

--- a/src/components/shared/AppWrapper/Header.tsx
+++ b/src/components/shared/AppWrapper/Header.tsx
@@ -16,16 +16,18 @@ export default function Header(): JSX.Element {
           setOpen(state.isOpen);
         }}
       >
-        {Array.from(PageMapping.keys()).map((path) => (
-          <Link
-            key={path}
-            onClick={() => setOpen(false)}
-            className="menu-link"
-            to={path}
-          >
-            {PageMapping.get(path)?.pageName}
-          </Link>
-        ))}
+        {Array.from(PageMapping.keys()).map((path) =>
+          PageMapping.get(path)?.hidden ? null : (
+            <Link
+              key={path}
+              onClick={() => setOpen(false)}
+              className="menu-link"
+              to={path}
+            >
+              {PageMapping.get(path)?.pageName}
+            </Link>
+          )
+        )}
       </Menu>
       <div id="nav-header">
         <h3>{PageMapping.get(currPath)?.pageName}</h3>

--- a/src/components/shared/AppWrapper/Header.tsx
+++ b/src/components/shared/AppWrapper/Header.tsx
@@ -17,7 +17,7 @@ export default function Header(): JSX.Element {
         }}
       >
         {Array.from(PageMapping.keys()).map((path) =>
-          PageMapping.get(path)?.hidden ? null : (
+          PageMapping.get(path)?.hideHeader ? null : (
             <Link
               key={path}
               onClick={() => setOpen(false)}

--- a/src/components/shared/globalTypes.ts
+++ b/src/components/shared/globalTypes.ts
@@ -20,9 +20,9 @@ export enum HeaderSections {
 
 export const PageMapping: Map<
   string,
-  { component: () => JSX.Element; pageName: string }
+  { component: () => JSX.Element; pageName: string; hidden?: boolean }
 > = new Map([
-  ['/', { component: Landing, pageName: 'Landing' }],
+  ['/', { component: Landing, pageName: 'Landing', hidden: true }],
   ['/intro', { component: Intro, pageName: 'Intro to Linux' }],
   ['/stationary', { component: Stationary, pageName: 'Stationary' }],
   ['/moving', { component: Moving, pageName: 'Moving' }],

--- a/src/components/shared/globalTypes.ts
+++ b/src/components/shared/globalTypes.ts
@@ -1,3 +1,4 @@
+import Landing from '../pages/landing';
 import Creation from './../pages/creation';
 import Game from './../pages/game';
 import Intro from './../pages/intro';
@@ -21,6 +22,7 @@ export const PageMapping: Map<
   string,
   { component: () => JSX.Element; pageName: string }
 > = new Map([
+  ['/', { component: Landing, pageName: 'Landing' }],
   ['/intro', { component: Intro, pageName: 'Intro to Linux' }],
   ['/stationary', { component: Stationary, pageName: 'Stationary' }],
   ['/moving', { component: Moving, pageName: 'Moving' }],

--- a/src/components/shared/globalTypes.ts
+++ b/src/components/shared/globalTypes.ts
@@ -20,9 +20,9 @@ export enum HeaderSections {
 
 export const PageMapping: Map<
   string,
-  { component: () => JSX.Element; pageName: string; hidden?: boolean }
+  { component: () => JSX.Element; pageName: string; hideHeader?: boolean }
 > = new Map([
-  ['/', { component: Landing, pageName: 'Landing', hidden: true }],
+  ['/', { component: Landing, pageName: 'Landing', hideHeader: true }],
   ['/intro', { component: Intro, pageName: 'Intro to Linux' }],
   ['/stationary', { component: Stationary, pageName: 'Stationary' }],
   ['/moving', { component: Moving, pageName: 'Moving' }],


### PR DESCRIPTION
## Summary

For addressing the issue with the header in  #74 

- Added functionality to have menu items that have the "hideHeader" prop
- Added landing page to the map with the hideHeader prop to keep the header hidden and to avoid adding to the hamburger menu
- This avoids having to add the header to each component we want it in (most of them except the landing page)