### PR TITLE
Added filesystems into different pages and Terminal improvements

### DIFF
--- a/src/components/pages/creation.tsx
+++ b/src/components/pages/creation.tsx
@@ -1,7 +1,27 @@
 import '../../styles/global.scss';
+import { Directory, File } from '../shared/globalTypes';
 import Bar from '../shared/progressbar';
+import Task from '../shared/Task';
 
 function Creation(): JSX.Element {
+  const task1FS = new Directory('/', undefined, new Map(), '/', true);
+  const task1CWD = task1FS as Directory;
+
+  const task2FS = new Directory(
+    '/',
+    undefined,
+    new Map([
+      ['file1', new File('file1')],
+      ['file2', new File('file2')],
+      ['file3', new File('file3')],
+      ['dir', new Directory('dir')],
+      ['dir2', new Directory('dir2')],
+    ]),
+    '/',
+    true
+  );
+  const task2CWD = task2FS as Directory;
+
   return (
     <div>
       <h1 className="lesson-title">Creation and Deletion</h1>
@@ -10,117 +30,194 @@ function Creation(): JSX.Element {
         So let’s start with making commands.
       </p>
       <br />
-      <h2 className="heading-1">
-        The <span className="command-in-heading">touch</span> Command
-      </h2>
-      <p className="body">
-        The <span className="try-out-command">touch</span> command makes a new
-        empty file.
-      </p>
-      <p className="body">
-        Run <span className="try-out-command">touch emptyFile</span> and see how
-        the file system diagram changes.
-      </p>
-      <p className="body">
-        If you then run <span className="try-out-command">cat emptyFile</span>,
-        notice how nothing is printed because the file has no contents!
-      </p>
-      <h2 className="heading-1">
-        The <span className="command-in-heading">mkdir</span> Command
-      </h2>
-      <p className="body">
-        The <span className="try-out-command">mkdir</span> command makes a new
-        empty directory.
-      </p>
-      <p className="body">
-        Run <span className="try-out-command">mkdir newDir</span> and see how
-        the file system diagram changes.
-      </p>
-      <p className="body">
-        Notice how you can now change into the newly-created directory with{' '}
-        <span className="try-out-command">cd newDir</span> !
-      </p>
-      <p className="body">
-        Removing commands are quite similar (plus, the names basically tell you
-        what the command does!).
-      </p>
-      <h2 className="heading-1">
-        The <span className="command-in-heading">rm</span> Command
-      </h2>
-      <p className="body">
-        The <span className="try-out-command">rm</span> command removes an
-        existing file.
-        <br />
-        Looks like we have three files in the current directory.
-        <br />
-        Go ahead and remove one of them with the command{' '}
-        <span className="try-out-command">rm fileName</span>.
-        <br />
-        Can rm be used to remove a directory? Give it a try.
-        <br />
-        Notice how the file system diagram remains unchanged because rm cannot
-        be used to remove directories.
-        <br />
-        The terminal also printed an error message: rm: DIRNAME: is a directory
-      </p>
-      <h2 className="heading-1">
-        The <span className="command-in-heading">rmdir</span> Command
-      </h2>
-      <p className="body">
-        The rmdir command removes an existing empty directory.
-        <br />
-        Try running <span className="try-out-command">rmdir nonemptyDir</span>.
-        <br />
-        Notice how the terminal prints the error message: rmdir: nonemptyDir:
-        Directory not empty
-        <br />
-        We could manually rm all the files in a directory one by one, but
-        there’s an easier way: the -rf options combination.
-        <br />
-        For example,
-        <br />
-        <span className="try-out-command">rm -rf nonemptyDir</span> recursively
-        and forcefully (i.e., does not ask for confirmation)
-        <br />
-        removes all files within the nonemptyDir directory.
-      </p>
-      <h2 className="heading-1">
-        The <span className="command-in-heading">cp</span> Command
-      </h2>
-      <p className="body">
-        The cp command copies one file to another.
-        <br />
-        <span className="try-out-command">
-          cp sourceFile destinationFile
-        </span>{' '}
-        copies the contents of sourceFile into destinationFile,
-        <br />
-        though the two will have different timestamps.
-        <br />
-        <span className="try-out-command">
-          cp file1 file2 directoryPath
-        </span>{' '}
-        copies the contents of file1 and file2 to two new files in the
-        directoryPath directory,
-        <br />
-        though the two new files will have different timestamps from the two
-        original files.
-      </p>
-      <h2 className="heading-1">
-        The <span className="command-in-heading">mv</span> Command
-      </h2>
-      <p className="body">
-        The mv command moves/renames files.
-        <br />
-        <span className="try-out-command">mv oldName newName</span> renames a
-        file called oldName to newName, with the timestamp remaining unchanged.
-        <br />
-        <span className="try-out-command">
-          mv file1 file2 directoryPath
-        </span>{' '}
-        moves file1 and file2 to directoryPath, with the timestamps remaining
-        unchanged.
-      </p>
+      <Task
+        taskPrompt={
+          <>
+            <p className="body task-prompt">
+              The <span className="try-out-command">touch</span> command makes a
+              new empty file.
+            </p>
+            <p className="body task-prompt">
+              Run <span className="try-out-command">touch emptyFile</span> and
+              see how the file system diagram changes.
+            </p>
+            <p className="body task-prompt">
+              If you then run{' '}
+              <span className="try-out-command">cat emptyFile</span>, notice how
+              nothing is printed because the file has no contents!
+            </p>
+          </>
+        }
+        taskName={
+          <h2 className="heading-1 task-name">
+            The <span className="command-in-heading">touch</span> Command
+          </h2>
+        }
+        completed={false}
+        fileSystem={task1FS}
+        currentWorkingDirectory={task1CWD}
+        displayFileSystem={true}
+      />
+      <Task
+        taskPrompt={
+          <>
+            <p className="body task-prompt">
+              The <span className="try-out-command">mkdir</span> command makes a
+              new empty directory.
+            </p>
+            <p className="body task-prompt">
+              Run <span className="try-out-command">mkdir newDir</span> and see
+              how the file system diagram changes.
+            </p>
+            <p className="body task-prompt">
+              Notice how you can now change into the newly-created directory
+              with <span className="try-out-command">cd newDir</span> !
+            </p>
+            <p className="body task-prompt">
+              Removing commands are quite similar (plus, the names basically
+              tell you what the command does!).
+            </p>
+          </>
+        }
+        taskName={
+          <h2 className="heading-1 task-name">
+            The <span className="command-in-heading">mkdir</span> Command
+          </h2>
+        }
+        completed={false}
+        fileSystem={task1FS}
+        currentWorkingDirectory={task1CWD}
+        displayFileSystem={true}
+      />
+
+      <Task
+        taskPrompt={
+          <>
+            <p className="body task-prompt">
+              The <span className="try-out-command">rm</span> command removes an
+              existing file.
+              <br />
+              Looks like we have three files in the current directory.
+              <br />
+              Go ahead and remove one of them with the command{' '}
+              <span className="try-out-command">rm fileName</span>.
+              <br />
+              Can rm be used to remove a directory? Give it a try.
+              <br />
+              Notice how the file system diagram remains unchanged because rm
+              cannot be used to remove directories.
+              <br />
+              The terminal also printed an error message: rm: DIRNAME: is a
+              directory
+            </p>
+          </>
+        }
+        taskName={
+          <h2 className="heading-1 task-name">
+            The <span className="command-in-heading">rm</span> Command
+          </h2>
+        }
+        completed={false}
+        fileSystem={task2FS}
+        currentWorkingDirectory={task2CWD}
+        displayFileSystem={true}
+      />
+      <Task
+        taskPrompt={
+          <>
+            <p className="body task-prompt">
+              The rmdir command removes an existing empty directory.
+              <br />
+              Try running{' '}
+              <span className="try-out-command">rmdir nonemptyDir</span>.
+              <br />
+              Notice how the terminal prints the error message: rmdir:
+              nonemptyDir: Directory not empty
+              <br />
+              We could manually rm all the files in a directory one by one, but
+              there’s an easier way: the -rf options combination.
+              <br />
+              For example,
+              <br />
+              <span className="try-out-command">rm -rf nonemptyDir</span>{' '}
+              recursively and forcefully (i.e., does not ask for confirmation)
+              <br />
+              removes all files within the nonemptyDir directory.
+            </p>
+          </>
+        }
+        taskName={
+          <h2 className="heading-1 task-name">
+            The <span className="command-in-heading">rmdir</span> Command
+          </h2>
+        }
+        completed={false}
+        fileSystem={task2FS}
+        currentWorkingDirectory={task2CWD}
+        displayFileSystem={true}
+      />
+      <Task
+        taskPrompt={
+          <>
+            <p className="body task-prompt">
+              The cp command copies one file to another.
+              <br />
+              <span className="try-out-command">
+                cp sourceFile destinationFile
+              </span>{' '}
+              copies the contents of sourceFile into destinationFile,
+              <br />
+              though the two will have different timestamps.
+              <br />
+              <span className="try-out-command">
+                cp file1 file2 directoryPath
+              </span>{' '}
+              copies the contents of file1 and file2 to two new files in the
+              directoryPath directory,
+              <br />
+              though the two new files will have different timestamps from the
+              two original files.
+            </p>
+          </>
+        }
+        taskName={
+          <h2 className="heading-1 task-name">
+            The <span className="command-in-heading">cp</span> Command
+          </h2>
+        }
+        completed={false}
+        fileSystem={task2FS}
+        currentWorkingDirectory={task2CWD}
+        displayFileSystem={true}
+      />
+      <Task
+        taskPrompt={
+          <>
+            <p className="body task-prompt">
+              The mv command moves/renames files.
+              <br />
+              <span className="try-out-command">mv oldName newName</span>{' '}
+              renames a file called oldName to newName, with the timestamp
+              remaining unchanged.
+              <br />
+              <span className="try-out-command">
+                mv file1 file2 directoryPath
+              </span>{' '}
+              moves file1 and file2 to directoryPath, with the timestamps
+              remaining unchanged.
+            </p>
+          </>
+        }
+        taskName={
+          <h2 className="heading-1 task-name">
+            The <span className="command-in-heading">mv</span> Command
+          </h2>
+        }
+        completed={false}
+        fileSystem={task2FS}
+        currentWorkingDirectory={task2CWD}
+        displayFileSystem={true}
+      />
       <br />
       <Bar totalsteps={6} currentstep={1} />
       <footer>

--- a/src/components/pages/moving.tsx
+++ b/src/components/pages/moving.tsx
@@ -1,8 +1,26 @@
 import tuxHoldingEgg from '../../assets/images/tux-hugging-egg.svg';
 import '../../styles/global.scss';
+import { Directory, File } from '../shared/globalTypes';
 import Task from '../shared/Task';
 
 function Moving(): JSX.Element {
+  const task1FS = new Directory(
+    '/',
+    undefined,
+    new Map([['Notes', new Directory('Notes', undefined)]]),
+    '/',
+    true
+  );
+  const task1CWD = task1FS as Directory;
+  const task2FS = new Directory(
+    '/',
+    undefined,
+    new Map([['.secret', new File('.secret', undefined, 'CS35L')]]),
+    '/',
+    true
+  );
+  const task2CWD = task2FS as Directory;
+
   return (
     <div>
       <h1 className="lesson-title">Moving Around the File System</h1>
@@ -57,9 +75,9 @@ function Moving(): JSX.Element {
         }
         taskName="Task 1"
         completed={false}
-        fileSystem={undefined}
-        currentWorkingDirectory={undefined}
-      ></Task>
+        fileSystem={task1FS}
+        currentWorkingDirectory={task1CWD}
+      />
       <Task
         taskPrompt={
           <p className="body task-prompt">
@@ -69,9 +87,10 @@ function Moving(): JSX.Element {
         }
         taskName="Task 2"
         completed={false}
-        fileSystem={undefined}
-        currentWorkingDirectory={undefined}
-      ></Task>
+        fileSystem={task2FS}
+        currentWorkingDirectory={task2CWD}
+        displayFileSystem={true}
+      />
       <footer>
         <a href="stationary">
           <button type="button" className="back-button">

--- a/src/components/pages/permissions.tsx
+++ b/src/components/pages/permissions.tsx
@@ -1,5 +1,6 @@
 import tuxHoldingEgg from '../../assets/images/tux-egg-flippers-raised.svg';
 import '../../styles/global.scss';
+import { Directory, File } from '../shared/globalTypes';
 import Task from './../shared/Task';
 
 function Permissions(): JSX.Element {
@@ -9,6 +10,14 @@ function Permissions(): JSX.Element {
      aliqua. Ut enim ad minim veniam, quis nostrud exercitation\
      ullamco laboris nisi ut aliquip ex ea commodo consequat.',
   ];
+  const initFileSystem = new Directory(
+    '/',
+    undefined,
+    new Map([['mystery.txt', new File('mystery.txt', 'wow, what a mystery')]]),
+    '/',
+    true
+  );
+  const currentWorkingDirectory = initFileSystem;
   return (
     <div>
       <div className="permissionContainer">
@@ -110,6 +119,8 @@ function Permissions(): JSX.Element {
           taskPrompt={taskPrompts[0]}
           taskName={'Task 1'}
           completed={false}
+          fileSystem={initFileSystem}
+          currentWorkingDirectory={currentWorkingDirectory}
         />
         <img
           src={tuxHoldingEgg}

--- a/src/components/pages/piping.tsx
+++ b/src/components/pages/piping.tsx
@@ -1,9 +1,18 @@
 import tuxHoldingEgg from '../../assets/images/tux-holding-egg.svg';
 import '../../styles/global.scss';
 import '../../styles/piping.scss';
+import { Directory, File } from '../shared/globalTypes';
 import Task from '../shared/Task';
 
 function Piping(): JSX.Element {
+  const initFileSystem = new Directory(
+    '/',
+    undefined,
+    new Map([['mystery.txt', new File('mystery.txt', 'wow, what a mystery')]]),
+    '/',
+    true
+  );
+  const currentWorkingDirectory = initFileSystem;
   return (
     <div className="lesson-container">
       <h1 className="lesson-title">Piping/IO Redirection</h1>
@@ -103,8 +112,8 @@ function Piping(): JSX.Element {
         }
         taskName="Task 1"
         completed={false}
-        fileSystem={undefined}
-        currentWorkingDirectory={undefined}
+        fileSystem={initFileSystem}
+        currentWorkingDirectory={currentWorkingDirectory}
       ></Task>
       <div className="section">
         <h2 className="heading-1">
@@ -142,8 +151,8 @@ function Piping(): JSX.Element {
         }
         taskName="Task 2"
         completed={false}
-        fileSystem={undefined}
-        currentWorkingDirectory={undefined}
+        fileSystem={initFileSystem}
+        currentWorkingDirectory={currentWorkingDirectory}
       ></Task>
       <footer>
         <a href="creation">

--- a/src/components/pages/searching.tsx
+++ b/src/components/pages/searching.tsx
@@ -99,6 +99,8 @@ function Searching(): JSX.Element {
             taskPrompt={taskPrompts[1]}
             taskName="Task 2"
             completed={false}
+            fileSystem={initFileSystem}
+            currentWorkingDirectory={currentWorkingDirectory}
           />
         </div>
         <footer>

--- a/src/components/pages/stationary.tsx
+++ b/src/components/pages/stationary.tsx
@@ -1,8 +1,18 @@
 import tuxBehindIgloo from '../../assets/images/tux-behind-igloo.svg';
 import '../../styles/global.scss';
+import { Directory } from '../shared/globalTypes';
 import Task from '../shared/Task';
 
 function Stationary(): JSX.Element {
+  const task1FS = new Directory(
+    '/',
+    undefined,
+    new Map([['igloo', new Directory('igloo', undefined)]]),
+    '/',
+    true
+  );
+  const task1CWD = task1FS.getChild('igloo') as Directory;
+
   return (
     <div>
       <h1 className="lesson-title">Stationary Commands</h1>
@@ -40,9 +50,9 @@ function Stationary(): JSX.Element {
         taskPrompt={'Try it out in the terminal! Where is Tux?'}
         taskName="Task 1"
         completed={false}
-        fileSystem={undefined}
-        currentWorkingDirectory={undefined}
-      ></Task>
+        fileSystem={task1FS}
+        currentWorkingDirectory={task1CWD}
+      />
 
       <h2 className="heading-1">
         The <span className="command-in-heading">whoami</span> Command
@@ -57,9 +67,9 @@ function Stationary(): JSX.Element {
         taskPrompt={"Can you figure out Tux's username?"}
         taskName="Task 2"
         completed={false}
-        fileSystem={undefined}
-        currentWorkingDirectory={undefined}
-      ></Task>
+        fileSystem={task1FS}
+        currentWorkingDirectory={task1CWD}
+      />
       <h2 className="heading-1">
         The <span className="command-in-heading">man</span> command
       </h2>
@@ -80,9 +90,9 @@ function Stationary(): JSX.Element {
         }
         taskName="Task 3"
         completed={false}
-        fileSystem={undefined}
-        currentWorkingDirectory={undefined}
-      ></Task>
+        fileSystem={task1FS}
+        currentWorkingDirectory={task1CWD}
+      />
       <footer>
         <a href="intro">
           <button type="button" className="back-button">

--- a/src/components/shared/Task.tsx
+++ b/src/components/shared/Task.tsx
@@ -7,14 +7,26 @@ import { Directory } from './globalTypes';
 import Terminal from './Terminal';
 import './../../styles/global.scss';
 
-function Task(prop: {
+const defaultProps = {
+  displayFileSystem: false,
+  completed: false,
+};
+
+type TaskProps = {
   taskPrompt: JSX.Element | string;
-  taskName: string;
-  completed: boolean;
-  fileSystem?: Directory;
-  currentWorkingDirectory?: Directory;
-  displayFileSystem?: boolean;
-}): JSX.Element {
+  taskName: JSX.Element | string;
+  fileSystem: Directory;
+  currentWorkingDirectory: Directory;
+} & typeof defaultProps;
+
+function Task({
+  taskPrompt,
+  taskName,
+  completed,
+  fileSystem,
+  currentWorkingDirectory,
+  displayFileSystem,
+}: TaskProps): JSX.Element {
   const ref = useRef(null);
   const [dimensions, setDimensions] = useState({
     renderWidth: 0,
@@ -37,12 +49,8 @@ function Task(prop: {
     }
   }
 
-  const [fileSystem, setFileSystem] = useState<Directory | undefined>(
-    prop.fileSystem
-  );
-  const [currentWorkingDirectory, setCurrentWorkingDirectory] = useState<
-    Directory | undefined
-  >(prop.fileSystem);
+  const [root, setRoot] = useState<Directory>(fileSystem);
+  const [CWD, setCWD] = useState<Directory>(currentWorkingDirectory);
 
   useEffect(() => {
     handleResize(ref);
@@ -55,28 +63,32 @@ function Task(prop: {
       <span className="task-header">
         <IconContext.Provider
           value={{
-            className: prop.completed ? 'complete' : 'incomplete',
+            className: completed ? 'complete' : 'incomplete',
             size: '1.5em',
           }}
         >
           <AiFillCheckCircle />
         </IconContext.Provider>
-        <h2 className="heading-1 task-name">{prop.taskName}</h2>
+        {typeof taskName === 'string' ? (
+          <h2 className="heading-1 task-name">{taskName}</h2>
+        ) : (
+          taskName
+        )}
       </span>
-      {typeof prop.taskPrompt === 'string' ? (
-        <p className="body task-prompt">{prop.taskPrompt}</p>
+      {typeof taskPrompt === 'string' ? (
+        <p className="body task-prompt">{taskPrompt}</p>
       ) : (
-        prop.taskPrompt
+        taskPrompt
       )}
       <div className="task-content" ref={ref}>
-        {fileSystem && prop.displayFileSystem && (
-          <FileSystemRender data={fileSystem} renderDimensions={dimensions} />
+        {displayFileSystem && (
+          <FileSystemRender data={root} renderDimensions={dimensions} />
         )}
         <Terminal
-          fileSystem={fileSystem as Directory}
-          currentWorkingDirectory={currentWorkingDirectory as Directory}
-          setFileSystem={setFileSystem}
-          setCurrentWorkingDirectory={setCurrentWorkingDirectory}
+          fileSystem={root}
+          currentWorkingDirectory={CWD}
+          setFileSystem={setRoot}
+          setCurrentWorkingDirectory={setCWD}
         />
         {/* TODO: Fix styling for ice-glare-left if displaying the file system render */}
         <div className="ice-glare-left">
@@ -188,5 +200,5 @@ function Task(prop: {
     </div>
   );
 }
-
+Task.defaultProps = defaultProps;
 export default Task;

--- a/src/styles/Task.scss
+++ b/src/styles/Task.scss
@@ -18,10 +18,6 @@
   width: 100%;
 }
 
-.task-name {
-  margin-left: 1vh;
-}
-
 .task-content {
   align-self: center;
   background-color: #e0edf8;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -120,3 +120,7 @@ body {
   margin-right: 0;
   text-align: left;
 }
+
+.task-name {
+  margin-left: 1vh;
+}


### PR DESCRIPTION
## Summary

Continuing work for #109

- Added filesystems for each terminal to make all terminals across all pages functional.
- Added Tasks for the Create/Delete page
- Added support for JSX Task headers
- Addressed type issues with Directory (`as Directory` before accessing methods of the Directory class)
- Added prop deconstruction for Tasks and support for optional props
- Added newline output for empty files
- Made filesystem and cwd mandatory for Task

## Test Plan
Sorry for the potato quality for the first clip.

https://user-images.githubusercontent.com/13056466/197450252-6bff13ee-1b67-479e-a5c9-1d47e4258379.mov

https://user-images.githubusercontent.com/13056466/197450517-6a92d41c-4e2d-412f-bdde-d740b3b8f2d4.mov



