### PR TITLE
fix: mv and cp for renaming with single source

### DIFF
--- a/src/components/shared/Terminal.tsx
+++ b/src/components/shared/Terminal.tsx
@@ -321,7 +321,8 @@ function Terminal(prop: {
         prevRes.cwdCopy ? prevRes.cwdCopy : undefined,
         prevRes.fileSystemCopy ? prevRes.fileSystemCopy : undefined
       );
-      if (prevRes.err.length > 0) {
+      error = prevRes.err.map((err) => err.replace('rm', 'mv'));
+      if (error.length > 0) {
         return error;
       }
     }

--- a/src/components/shared/Terminal.tsx
+++ b/src/components/shared/Terminal.tsx
@@ -236,7 +236,7 @@ function Terminal(prop: {
         result.err = [`cp: '${destination}': Not a directory`];
         return result;
       }
-    } else if (!destDir) {
+    } else if (!destDir || !destDir.isDirectory) {
       const tempDest = destination.split('/');
       newFileName = tempDest.pop() || '';
       destination = tempDest.join('/');

--- a/src/components/shared/Terminal.tsx
+++ b/src/components/shared/Terminal.tsx
@@ -225,6 +225,7 @@ function Terminal(prop: {
       : cwdCopy.getFileSystemObjectFromPath(destination);
 
     let newFileName = '';
+    let rename = false;
 
     if (paths.length > 1) {
       if (!destDir) {
@@ -252,30 +253,7 @@ function Terminal(prop: {
         result.err = [`cp: '${destination}': Not a directory`];
         return result;
       }
-
-      const path = paths[0];
-      const file = path.startsWith('/')
-        ? prop.fileSystem.getFileSystemObjectFromPath(path)
-        : prop.currentWorkingDirectory.getFileSystemObjectFromPath(path);
-
-      if (!file) {
-        result.err = [`cp: '${path}': No such file or directory`];
-        return result;
-      }
-      if (file.isDirectory && !flags.toLowerCase().includes('r')) {
-        result.err = [`cp: '${path}' is a directory (not copied)`];
-        return result;
-      }
-
-      const childDir = (destDir as Directory).getChild(newFileName);
-      const newFile = _.cloneDeep(file);
-      if (childDir && childDir.isDirectory) {
-        destDir = childDir;
-      } else {
-        newFile.name = newFileName;
-      }
-
-      newFiles.push(newFile);
+      rename = true;
     }
 
     for (const path of paths) {
@@ -285,7 +263,7 @@ function Terminal(prop: {
 
       // If the path is absolute, find the directory to create the file in
       // Otherwise, use the current working directory
-      newFileName = path.split('/').pop() || '';
+      newFileName = !rename ? path.split('/').pop() || '' : newFileName;
 
       if (!file) {
         result.err = [`cp: '${path}': No such file or directory`];


### PR DESCRIPTION
## Summary

Previous PR accidentally removed cp (and mv) functionality to rename the file when given a single source file. Added more testing examples to more rigorously test this. 

Continues work for #109

- Added check to see if the number of arguments is sufficient to attempt renaming the file
- Change the destination directory to be everything except the renamed file

## Test Plan

https://user-images.githubusercontent.com/13056466/209738825-9e753222-3768-4220-961a-e175a0f6c922.mov

More rigorous testing (Potato quality because video too large, sorry)

https://user-images.githubusercontent.com/13056466/209739573-083df171-4d71-49bd-8613-4362e44182a9.mov


