### PR TITLE
fix: clear command

### DIFF
--- a/src/components/shared/Terminal.tsx
+++ b/src/components/shared/Terminal.tsx
@@ -17,7 +17,7 @@ function Terminal(prop: {
   const [inputHistory, setInputHistory] = useState<string[]>([]);
   const [inputHistoryIndex, setInputHistoryIndex] = useState(0);
 
-  function processInput(usertyped: string) {
+  function processInput(usertyped: string): TerminalCommandResult {
     const userInput = usertyped.trim().split(' ');
     const command = input.length > 1 ? userInput.slice(1, 2).join(' ') : '';
     const args = userInput.slice(2);
@@ -33,7 +33,6 @@ function Terminal(prop: {
     let path = args.slice(i).join(' ');
     path ||= '.';
 
-    console.log('Command: ' + command, 'Flags: ' + flags, 'Path: ' + path);
     const result: TerminalCommandResult = executeCommand(
       _.cloneDeep(prop.fileSystem),
       _.cloneDeep(prop.currentWorkingDirectory),
@@ -42,7 +41,7 @@ function Terminal(prop: {
       flags
     );
 
-    const { modifiedCWD, modifiedFS, err, out } = result;
+    const { modifiedCWD, modifiedFS } = result;
 
     if (modifiedFS) {
       prop.setFileSystem(modifiedFS);
@@ -50,8 +49,7 @@ function Terminal(prop: {
     if (modifiedCWD) {
       prop.setCurrentWorkingDirectory(modifiedCWD);
     }
-
-    return { err, out };
+    return result;
   }
 
   function handleChange(e: React.FormEvent<HTMLInputElement>) {
@@ -66,12 +64,12 @@ function Terminal(prop: {
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const result = processInput(input);
+    const { err, out, clear } = processInput(input);
     const newHistory = [...inputHistory, input];
-    if (result.err.length > 0 && result.err[0] === 'CLEAR') {
+    if (clear) {
       setCommands([]);
     } else {
-      setCommands([...commands, input, ...result.err, ...result.out]);
+      setCommands([...commands, input, ...err, ...out]);
     }
     prop.getLastCommand(input);
     setInputHistory(newHistory);

--- a/src/components/shared/TerminalCommands.ts
+++ b/src/components/shared/TerminalCommands.ts
@@ -7,6 +7,7 @@ export interface TerminalCommandResult {
   modifiedCWD: Directory | null;
   err: string[];
   out: string[];
+  clear?: boolean;
 }
 
 export function getFSObjectHelper(
@@ -119,7 +120,7 @@ export function executeCommand(
     case 'chmod':
       break;
     case 'clear':
-      result.out = ['CLEAR'];
+      result.clear = true;
       break;
     default:
       result.out = ['Invalid command. Try again.'];


### PR DESCRIPTION
## Summary

Continue work for #109. Fixing broken clear command. Small refactor adding clear as an option in the TerminalCommandResult interface (because the previous code has the very minor edge case of having CLEAR error result in clearing the terminal, which is not a great solution).

## Test Plan

Retested terminal functionality, history, and clearing. This process of retesting and ensuring good coverage is quite tedious, I think a later improvement that should be made is unit testing with Jest to automate this process. Of course, E2E + unit test is preferable, but I think having some barebones tests would reduce churn from breaking preexisting terminal functionality.
