### PR TITLE
feat: grep

### DIFF
--- a/src/components/shared/Terminal.tsx
+++ b/src/components/shared/Terminal.tsx
@@ -98,6 +98,13 @@ function Terminal(prop: {
     }
   }
 
+  function colorHighlight(command: string) {
+    if (!command.includes('<span>')) {
+      return <p className="command">{command}</p>;
+    }
+    return <span dangerouslySetInnerHTML={{ __html: command }} />;
+  }
+
   return (
     <div className="terminal">
       <div>
@@ -105,9 +112,7 @@ function Terminal(prop: {
           return command === '\n' ? (
             <br key={key} />
           ) : (
-            <p className="command" key={key}>
-              {command}
-            </p>
+            <span key={key}>{colorHighlight(command)}</span>
           );
         })}
       </div>

--- a/src/components/shared/Terminal.tsx
+++ b/src/components/shared/Terminal.tsx
@@ -69,7 +69,7 @@ function Terminal(prop: {
     if (clear) {
       setCommands([]);
     } else {
-      setCommands([...commands, input, ...err, ...out]);
+      setCommands([...commands, input, ...err, out.join('<br/>')]);
     }
     prop.getLastCommand(input);
     setInputHistory(newHistory);

--- a/src/styles/Terminal.scss
+++ b/src/styles/Terminal.scss
@@ -30,6 +30,10 @@
   width: 100%;
 }
 
+span span span {
+  color: palevioletred;
+}
+
 .terminal-top-icicle {
   position: absolute;
   right: -10px;


### PR DESCRIPTION
## Summary

Continues work for #109 by adding support for grep! This PR adds the following:
- grep command with -r flag for recursive search through directories
  - BFS search through directories using provided file to find matching text
  - Returns all files that match (with correct color highlighting)
  - Enables support for either 1 arg grep with -r flag or 2 arg grep or 2 arg grep with -r flag
- Searches for text in file and displays matching part with color 
  - Keen-eyed Cyber people may notice a neat little XSS vulnerability (along with sinful CSS). I'm not a fan of it either, but the alternative solution would require reworking the way commands are displayed and passing a flag, which will be a future TODO. 

## Test Plan

https://user-images.githubusercontent.com/13056466/210133647-caca7322-598a-478a-b9aa-379313feac5d.mov

https://user-images.githubusercontent.com/13056466/210134275-e3491107-a775-41d0-90ae-226010a8f477.mov


