### PR TITLE
fix: support for grep 

### DIFF
--- a/src/components/shared/TerminalCommands.ts
+++ b/src/components/shared/TerminalCommands.ts
@@ -551,6 +551,8 @@ function executeGrep(
 ): TerminalCommandResult {
   path ||= '.';
 
+  path = path === '*' ? '.' : path;
+
   const result: TerminalCommandResult = {
     modifiedFS: null,
     modifiedCWD: null,


### PR DESCRIPTION
Add support for `grep -R something *`

## Summary
Treats the "*" option as "." as a temporary fix

Continue work for #109

## Test Plan
<img width="908" alt="Screen Shot 2022-12-31 at 10 25 54 PM" src="https://user-images.githubusercontent.com/13056466/210165009-647a4453-2569-4010-bbf1-25140474835c.png">
