### PR TITLE
feat: find command

### DIFF
--- a/src/components/pages/searching.tsx
+++ b/src/components/pages/searching.tsx
@@ -29,7 +29,10 @@ function Searching(): JSX.Element {
           'dir1',
           undefined,
           new Map([
-            ['glasses.txt', new File('glasses.txt', '/dir1/glasses.txt')],
+            [
+              'glasses.txt',
+              new File('glasses.txt', 'glasses here!', '/dir1/glasses.txt'),
+            ],
           ])
         ),
       ],

--- a/src/components/shared/Terminal.tsx
+++ b/src/components/shared/Terminal.tsx
@@ -38,7 +38,8 @@ function Terminal(prop: {
       _.cloneDeep(prop.currentWorkingDirectory),
       command,
       path,
-      flags
+      flags,
+      args
     );
 
     const { modifiedCWD, modifiedFS } = result;
@@ -69,7 +70,7 @@ function Terminal(prop: {
     if (clear) {
       setCommands([]);
     } else {
-      setCommands([...commands, input, ...err, out.join('<br/>')]);
+      setCommands([...commands, input, ...err, out.join('\n')]);
     }
     prop.getLastCommand(input);
     setInputHistory(newHistory);

--- a/src/components/shared/TerminalCommands.ts
+++ b/src/components/shared/TerminalCommands.ts
@@ -551,6 +551,8 @@ function executeGrep(
 ): TerminalCommandResult {
   path ||= '.';
 
+  path = path === '*' ? '.' : path;
+
   const result: TerminalCommandResult = {
     modifiedFS: null,
     modifiedCWD: null,

--- a/src/components/shared/TerminalCommands.ts
+++ b/src/components/shared/TerminalCommands.ts
@@ -641,7 +641,6 @@ function executeGrep(
       }
     }
   }
-  console.log(result);
   return result;
 }
 
@@ -706,7 +705,6 @@ function executeFind(
     const matchingName = !fileToFind || curr.name.includes(fileToFind);
 
     if (matchingType && matchingName) {
-      console.log('Explored match', curr);
       result.out.push(curr.path);
     }
 

--- a/src/components/shared/TerminalCommands.ts
+++ b/src/components/shared/TerminalCommands.ts
@@ -38,7 +38,8 @@ export function executeCommand(
   currentWorkingDirectory: Directory,
   command: string,
   path: string,
-  flags: string
+  flags: string,
+  rawArgs: string[]
 ): TerminalCommandResult {
   let result: TerminalCommandResult = {
     modifiedFS: null,
@@ -132,7 +133,49 @@ export function executeCommand(
       }
       break;
     case 'find':
-      result = executeFind(path, flags);
+      {
+        // This is a temporary solution for processing the arguments,
+        // a better universal arg parser should be applied instead
+
+        let invalid = false;
+        const args = [];
+        const findFlags: Map<string, string> = new Map<string, string>();
+
+        // Rough way of checking correct usage based on number or arguments
+        // So far we only support -type and -name
+        if (rawArgs.length === 0 || rawArgs.length > 6) {
+          invalid = true;
+        }
+
+        for (let i = 0; i < rawArgs.length; i++) {
+          if (rawArgs[i].startsWith('-')) {
+            if (i + 1 >= rawArgs.length) {
+              invalid = true;
+              break;
+            }
+            if (rawArgs[i + 1].startsWith('-')) {
+              invalid = true;
+              break;
+            } else {
+              findFlags.set(rawArgs[i].slice(1), rawArgs[i + 1]);
+              i++;
+            }
+          } else {
+            args.push(rawArgs[i]);
+          }
+        }
+
+        if (invalid) {
+          result.err = ['find: invalid usage'];
+          return result;
+        }
+        result = executeFind(
+          fileSystem,
+          currentWorkingDirectory,
+          args,
+          findFlags
+        );
+      }
       break;
     case 'chmod':
       break;
@@ -150,17 +193,6 @@ function executeMan(command: string): string[] {
   return manPages[command]
     ? [manPages[command]]
     : ['Command invalid for purposes of this learning lab'];
-}
-
-function executeFind(path: string, flags: string): TerminalCommandResult {
-  console.log('find', path, flags);
-  const result: TerminalCommandResult = {
-    modifiedFS: null,
-    modifiedCWD: null,
-    err: [],
-    out: [],
-  };
-  return result;
 }
 
 function executeList(
@@ -626,4 +658,65 @@ function findStringInFile(file: FileSystemObject, pattern: string) {
     }
   }
   return null;
+}
+
+function executeFind(
+  fileSystem: Directory,
+  cwd: Directory,
+  args: string[],
+  flags: Map<string, string>
+): TerminalCommandResult {
+  const result: TerminalCommandResult = {
+    modifiedFS: null,
+    modifiedCWD: null,
+    err: [],
+    out: [],
+  };
+  const path = args[0] || '.';
+  const fileToFind = flags.get('name') ?? args[1] ?? null;
+  const type = flags.get('type') ?? null;
+
+  const directoryToSearch = getFSObjectHelper(
+    path,
+    fileSystem,
+    cwd,
+    () => `find: ${path}: No such file or directory`,
+    () => `find ${path}: Not a directory`
+  );
+
+  // Supplied directory to search either does not exist or is a file
+  if (typeof directoryToSearch === 'string') {
+    result.err = [directoryToSearch];
+    return result;
+  }
+
+  const visited: string[] = [];
+  const queue: FileSystemObject[] = [];
+  queue.push(directoryToSearch as FileSystemObject);
+
+  while (queue.length > 0) {
+    const curr = queue.shift() as FileSystemObject;
+    if (visited.includes(curr.path)) {
+      continue;
+    }
+    visited.push(curr.path);
+
+    const currType = curr.isDirectory ? 'd' : 'f';
+    const matchingType = !type || type === currType;
+    const matchingName = !fileToFind || curr.name.includes(fileToFind);
+
+    if (matchingType && matchingName) {
+      console.log('Explored match', curr);
+      result.out.push(curr.path);
+    }
+
+    if (curr.isDirectory) {
+      if (!curr.children) {
+        continue;
+      }
+      curr.children.forEach((child) => queue.push(child));
+    }
+  }
+
+  return result;
 }

--- a/src/components/shared/globalTypes.ts
+++ b/src/components/shared/globalTypes.ts
@@ -106,6 +106,15 @@ export class Directory extends FileSystemObject {
     fileSystemObject.parent = this;
     fileSystemObject.path = this.getPathForChild(fileSystemObject.name);
     this.children.set(fileSystemObject.name, fileSystemObject);
+
+    // Recursively add children of children
+    this.children.forEach((child) => {
+      if (child.isDirectory && child.children) {
+        child.children.forEach((grandchild) => {
+          (child as Directory).addFileSystemObject(grandchild);
+        });
+      }
+    });
     return this;
   }
 

--- a/src/styles/Terminal.scss
+++ b/src/styles/Terminal.scss
@@ -30,6 +30,10 @@
   width: 100%;
 }
 
+span {
+  white-space: pre-line;
+}
+
 span span span {
   color: palevioletred;
 }


### PR DESCRIPTION
Note: This is a stacked PR, see #181 first. 

## Summary

Continues work for #109. Completed find command with `-name` and `-type` flags. Recursively searches for matching file names and returns the matching files. 

- Added support for printing out newlines in the output span (to avoid having to add `<br>`s
- Fixed paths for nested directories by recursively adding them
- Added way to parse arguments for find (these arguments behave differently since the value of the flag comes after, separated by a space).
- Basic error checking (e.g. file does not exist)

## Test Plan

https://user-images.githubusercontent.com/13056466/210697279-a3c1cca5-b8af-48c3-9f9e-44d071c2f650.mov

https://user-images.githubusercontent.com/13056466/210697441-ea923d13-eeea-45c6-bd90-c096e38d8e5e.mov


