### PR TITLE
feat: chmod

### DIFF
--- a/src/components/pages/permissions.tsx
+++ b/src/components/pages/permissions.tsx
@@ -17,13 +17,16 @@ function Permissions(): JSX.Element {
         'hiddenStuff.txt',
         new File(
           'hiddenStuff.txt',
-          'This is super secret info. I bet no one can read it.'
+          'This is super secret info. I bet no one can read it.',
+          '/hiddenStuff.txt',
+          ['---', '---', '---']
         ),
       ],
     ]),
     '/',
     true
   );
+
   const currentWorkingDirectory = initFileSystem;
   return (
     <>
@@ -57,7 +60,7 @@ function Permissions(): JSX.Element {
           <h2 className="heading-1 green">User Permissions</h2>
           <div className="body">
             The second through fourth letters are the <b>User permissions</b>.
-            The User is the owner of the file. They should have the most
+            The User is the user of the file. They should have the most
             permissions, as they created the file. In the example above, we see
             the User has{' '}
             <span className="try-out-command green-permissions">rwx</span>{' '}


### PR DESCRIPTION
## Summary

Continues work on #109. Almost done-ish!

- Add support for permissions in the filesystem (will come in handy for `ls -l`)
  - Very unnecessary, probably overkill, but fully implemented permissions
- `chmod` with a variety of arguments (e.g. `chmod +x`, `chmod -r [fileName]`) 
  - Also supports multiple permissions setting (delimited by comma)
- Added check to `cat` to verify if the user can read the file
- Added support for setting permissions using `chmod` and `=` (e.g. `chmod u=rwx,g=rx,o=r [fileName]`)
  - This feature isn't really tested too much though

## Test Plan
Had to `console.log` to verify permissions object changes correctly, as there currently exists no way to verify the correct permissions are being set for write/execute and for others/group.

https://user-images.githubusercontent.com/13056466/210795784-6e772cb8-8e65-497c-996e-441cfdebf93f.mov


