### PR TITLE
feat: ls long format

### DIFF
--- a/src/components/shared/TerminalCommands.ts
+++ b/src/components/shared/TerminalCommands.ts
@@ -726,6 +726,23 @@ function executeFind(
   return result;
 }
 
+function setAllPermissions(
+  permissionMap: Map<string, string>,
+  action: string,
+  role: string,
+  file: FileSystemObject
+): void {
+  const p = permissionMap.get(action);
+  const val = role === '+';
+  if (p === 'read' || p === 'write' || p === 'execute') {
+    Object.keys(file.permissions).forEach((r) => {
+      if (r === 'user' || r === 'group' || r === 'other') {
+        file.permissions[r][p] = val;
+      }
+    });
+  }
+}
+
 function executeChmod(
   fileSystem: Directory,
   cwd: Directory,
@@ -779,18 +796,12 @@ function executeChmod(
     if (permission.length == 2 && (role === '+' || role === '-')) {
       if (path === '.') {
         file.children?.forEach((child) => {
-          const p = permissionMap.get(action);
-          const val = role === '+';
-          if (p === 'read' || p === 'write' || p === 'execute') {
-            Object.keys(child.permissions).forEach((r) => {
-              if (r === 'user' || r === 'group' || r === 'other') {
-                child.permissions[r][p] = val;
-              }
-            });
-          }
+          setAllPermissions(permissionMap, action, role, child);
         });
-        continue;
+      } else {
+        setAllPermissions(permissionMap, action, role, file);
       }
+      continue;
     }
 
     // Minor error handling

--- a/src/components/shared/globalTypes.ts
+++ b/src/components/shared/globalTypes.ts
@@ -180,9 +180,9 @@ export class Directory extends FileSystemObject {
         child.permissions.other,
       ]) {
         // permissionString += ' ';
-        permissionString += `${permission.read ? 'r' : '\u2009-'}`;
-        permissionString += `${permission.write ? 'w' : '\u2009-'}`;
-        permissionString += `${permission.execute ? 'x' : '\u2009-'}`;
+        permissionString += `${permission.read ? '\u2009r' : '\u2009-'}`;
+        permissionString += `${permission.write ? '\u2009w' : '\u2009-'}`;
+        permissionString += `${permission.execute ? '\u2009x' : '\u2009-'}`;
       }
       const options = {
         month: 'long',

--- a/src/components/shared/globalTypes.ts
+++ b/src/components/shared/globalTypes.ts
@@ -170,32 +170,32 @@ export class Directory extends FileSystemObject {
 
   getChildrenNames(showHidden = false, longFormat = false): Array<string> {
     return this.getChildren(showHidden).map((child) => {
-      if (longFormat) {
-        let permissionString = '';
-        for (const permission of [
-          child.permissions.user,
-          child.permissions.group,
-          child.permissions.other,
-        ]) {
-          permissionString += ' ';
-          permissionString += `${permission.read ? 'r' : '-'}`;
-          permissionString += `${permission.write ? 'w' : '-'}`;
-          permissionString += `${permission.execute ? 'x' : '-'}`;
-        }
-        const options = {
-          month: 'long',
-          day: 'numeric',
-          hour: '2-digit',
-          minute: '2-digit',
-          hour12: false,
-        };
-        // The user is tux, so we just hardcode that
-        return `${permissionString} tux ${new Date().toLocaleString(
-          'en-us',
-          options
-        )} ${child.name}`;
+      if (!longFormat) {
+        return child.name;
       }
-      return child.name;
+      let permissionString = child.isDirectory ? 'd' : '-';
+      for (const permission of [
+        child.permissions.user,
+        child.permissions.group,
+        child.permissions.other,
+      ]) {
+        // permissionString += ' ';
+        permissionString += `${permission.read ? 'r' : '\u2009-'}`;
+        permissionString += `${permission.write ? 'w' : '\u2009-'}`;
+        permissionString += `${permission.execute ? 'x' : '\u2009-'}`;
+      }
+      const options = {
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      };
+      // The user is tux, so we just hardcode that
+      return `${permissionString} tux ${new Date().toLocaleString(
+        'en-us',
+        options
+      )} ${child.name}`;
     });
   }
 

--- a/src/components/shared/globalTypes.ts
+++ b/src/components/shared/globalTypes.ts
@@ -169,10 +169,34 @@ export class Directory extends FileSystemObject {
   }
 
   getChildrenNames(showHidden = false, longFormat = false): Array<string> {
-    if (longFormat) {
-      // TODO: implement long format
-    }
-    return this.getChildren(showHidden).map((child) => child.name);
+    return this.getChildren(showHidden).map((child) => {
+      if (longFormat) {
+        let permissionString = '';
+        for (const permission of [
+          child.permissions.user,
+          child.permissions.group,
+          child.permissions.other,
+        ]) {
+          permissionString += ' ';
+          permissionString += `${permission.read ? 'r' : '-'}`;
+          permissionString += `${permission.write ? 'w' : '-'}`;
+          permissionString += `${permission.execute ? 'x' : '-'}`;
+        }
+        const options = {
+          month: 'long',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+        };
+        // The user is tux, so we just hardcode that
+        return `${permissionString} tux ${new Date().toLocaleString(
+          'en-us',
+          options
+        )} ${child.name}`;
+      }
+      return child.name;
+    });
   }
 
   getChild(name: string): Directory | File | undefined {


### PR DESCRIPTION
## Summary

Continues work for #109. Almost done, only one more thing left!

- Adds support for ls long format using `ls -l`
   - Formats the permissions object into the standard long format output (e.g. `-rw-r--r--` or `drwxr-xr-x`)
   - Displays user "tux"
   - Time of file creation, hard-coded to be the current time as of now
   - For some reason, the font makes it so that dashes next to each other just combine into a line. To avoid that I add a very small amount of space using `/u2009`. Not the best solution, but works for now.
- Fixed chmod without role, but file provided (e.g. `chmod +r file`)

## Test Plan
ls long format with hidden directory (requires the `-a` flag) and file. The file by default has none of the permissions, while the newly created directory defaults to having all permissions enabled. Messed around with permissions using chmod to see if it's correctly reflected in the long format output. 

https://user-images.githubusercontent.com/13056466/211016175-483bdd59-6f72-4801-aa40-fcd16c836757.mov



